### PR TITLE
Downgrading required django version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'timezone_field',
     ],
     install_requires=[
-        'Django>=1.9',
+        'Django>=1.8',
         'pytz'
     ],
     tests_require=[


### PR DESCRIPTION
The version from mfogel only requires django 1.8.  I'm unsure if any changes made by you or wes require django 1.9, but as we are somehow using this package with django 1.8 currently.  I think we should be ok.